### PR TITLE
Feat: Add chopsticks configs for Muse and Mythos network

### DIFF
--- a/chopsticks-config/muse.yml
+++ b/chopsticks-config/muse.yml
@@ -1,0 +1,22 @@
+# Basic configuration for the Muse network.
+# It provides balance to an "Alice" account and set it to impersonate the "Sudo" account.
+
+endpoint: wss://rococo-muse-rpc.polkadot.io
+mock-signature-host: true
+block: ${env.MUSE_BLOCK_NUMBER}
+db: ./db.sqlite
+runtime-log-level: 5
+
+import-storage:
+  Sudo:
+    Key: "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"
+  System:
+    Account:
+      -
+        -
+          - "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"
+        - providers: 1
+          data:
+            free: "100000000000000000000000"
+
+

--- a/chopsticks-config/mythos-westend.yml
+++ b/chopsticks-config/mythos-westend.yml
@@ -1,0 +1,20 @@
+# Basic configuration for the Westend Mythos network.
+# It provides balance to an "Alice" account and set it to impersonate the "Sudo" account.
+
+endpoint: wss://westend-muse-rpc.polkadot.io
+mock-signature-host: true
+block: ${env.WMYTHOS_BLOCK_NUMBER}
+db: ./db.sqlite
+runtime-log-level: 5
+
+import-storage:
+  Sudo:
+    Key: "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"
+  System:
+    Account:
+      -
+        -
+          - "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"
+        - providers: 1
+          data:
+            free: "100000000000000000000000"

--- a/chopsticks-config/mythos.yml
+++ b/chopsticks-config/mythos.yml
@@ -1,0 +1,20 @@
+# Basic configuration for the Mythos network.
+# It provides balance to an "Alice" account and set it to impersonate the "Sudo" account.
+
+endpoint: wss://polkadot-mythos-rpc.polkadot.io
+mock-signature-host: true
+block: ${env.MYTHOS_BLOCK_NUMBER}
+db: ./db.sqlite
+runtime-log-level: 5
+
+import-storage:
+  Sudo:
+    Key: "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"
+  System:
+    Account:
+      -
+        -
+          - "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"
+        - providers: 1
+          data:
+            free: "100000000000000000000000"


### PR DESCRIPTION
## Description
Configs for running Acala's `Chopsticks` to locally fork both Muse and Mythos network.

## Chopsticks Quick Start

Install: 
`npm i @acala-network/chopsticks@latest`

Run Mythos local fork:
`npx @acala-network/chopsticks@latest --config=chopsticks-config/mythos.yml `

Run Muse local fork:
`npx @acala-network/chopsticks@latest --config=chopsticks-config/mythos.yml `

## Resources
[Chopstick's Github Repo](https://github.com/AcalaNetwork/chopsticks) 
[Moonbeam guide for useful examples](https://docs.moonbeam.network/builders/build/substrate-api/chopsticks/#__tabbed_2_3)