### PR TITLE
Fix: Adjust execute weight value to a usable value

### DIFF
--- a/runtime/mainnet/src/weights/pallet_xcm.rs
+++ b/runtime/mainnet/src/weights/pallet_xcm.rs
@@ -148,7 +148,7 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 18_446_744_073_709_551_000 picoseconds.
-		Weight::from_parts(18_446_744_073_709_551_000, 0)
+		Weight::from_parts(80_024_000, 0)
 			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// Storage: `PolkadotXcm::SupportedVersion` (r:0 w:1)


### PR DESCRIPTION
Moving weight back to the Kusama value approved by auditors. 