### PR TITLE
Generate issue report based previous month issues

### DIFF
--- a/.github/workflows/monthly-issue-metrics-report.yml
+++ b/.github/workflows/monthly-issue-metrics-report.yml
@@ -32,7 +32,7 @@ jobs:
       uses: github/issue-metrics@v3
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SEARCH_QUERY: 'repo:paritytech/project-mythical is:issue label:Infra'
+        SEARCH_QUERY: 'repo:paritytech/project-mythical is:issue created:${{ env.last_month }} label:Infra'
 
     - name: Create issue
       uses: peter-evans/create-issue-from-file@v5


### PR DESCRIPTION
Going forward the Infra issue report will be compiled every first day of the month.