### PR TITLE
Use MaxCalls for batch() benchmark on Multibatching pallet

### DIFF
--- a/pallets/multibatching/src/benchmarking.rs
+++ b/pallets/multibatching/src/benchmarking.rs
@@ -45,7 +45,7 @@ pub mod benchmarks {
 	use pallet_timestamp::Pallet as Timestamp;
 
 	#[benchmark]
-	fn batch(c: Linear<1, { T::MaxCalls::get() }>, s: Linear<1, 10>) {
+	fn batch(c: Linear<1, { T::MaxCalls::get() }>, s: Linear<1, { T::MaxCalls::get() }>) {
 		let call_count = c as usize;
 		let signer_count = s as usize;
 


### PR DESCRIPTION
Fix Multibatching benchmark to address issue #93
