### PR TITLE
Make multibatching domain configurable by runtime

### DIFF
--- a/pallets/multibatching/src/benchmarking.rs
+++ b/pallets/multibatching/src/benchmarking.rs
@@ -21,10 +21,6 @@ where
 	}
 }
 
-fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
-	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
-}
-
 #[benchmarks(
     where
         T::Signer: From<EthereumSigner>,
@@ -49,7 +45,7 @@ pub mod benchmarks {
 		let call_count = c as usize;
 		let signer_count = s as usize;
 
-		let domain: [u8; 32] = *b".myth.pallet-multibatching.bench";
+		let domain: [u8; 8] = T::Domain::get();
 		let bias = [0u8; 32];
 		let expires_at = Timestamp::<T>::get() + T::BenchmarkHelper::timestamp(100_000);
 
@@ -98,21 +94,8 @@ pub mod benchmarks {
 		}
 		approvals.sort_by_key(|a| a.from.clone());
 
-		Pallet::<T>::force_set_domain(RawOrigin::Root.into(), domain)
-			.expect("force_set_domain must succeed");
-
 		#[extrinsic_call]
 		_(RawOrigin::Signed(sender), domain, sender.into(), bias, expires_at, calls, approvals);
-	}
-
-	#[benchmark]
-	fn force_set_domain() {
-		let domain = [0; 32];
-
-		#[extrinsic_call]
-		_(RawOrigin::Root, domain);
-
-		assert_last_event::<T>(Event::DomainSet { domain }.into());
 	}
 
 	impl_benchmark_test_suite!(Multibatching, crate::mock::new_test_ext(), crate::mock::Test);

--- a/pallets/multibatching/src/mock.rs
+++ b/pallets/multibatching/src/mock.rs
@@ -65,12 +65,17 @@ impl pallet_timestamp::Config for Test {
 	type WeightInfo = ();
 }
 
+parameter_types! {
+	pub const DOMAIN: [u8;8] = *b"MYTH_NET";
+}
+
 impl pallet_multibatching::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
 	type Signature = Signature;
 	type Signer = <Signature as Verify>::Signer;
 	type MaxCalls = ConstU32<10>;
+	type Domain = DOMAIN;
 	type WeightInfo = ();
 	pallet_multibatching::runtime_benchmarks_enabled! {
 		type BenchmarkHelper = ();

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -368,12 +368,17 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = RuntimeFreezeReason;
 }
 
+parameter_types! {
+	pub const DOMAIN: [u8;8] = *b"MYTH_NET";
+}
+
 impl pallet_multibatching::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
 	type Signature = Signature;
 	type Signer = <Signature as Verify>::Signer;
 	type MaxCalls = ConstU32<128>;
+	type Domain = DOMAIN;
 	type WeightInfo = weights::pallet_multibatching::WeightInfo<Runtime>;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -367,12 +367,17 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = RuntimeFreezeReason;
 }
 
+parameter_types! {
+	pub const DOMAIN: [u8;8] = *b"MUSE_NET";
+}
+
 impl pallet_multibatching::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
 	type Signature = Signature;
 	type Signer = <Signature as Verify>::Signer;
 	type MaxCalls = ConstU32<128>;
+	type Domain = DOMAIN;
 	type WeightInfo = weights::pallet_multibatching::WeightInfo<Runtime>;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();


### PR DESCRIPTION
Based on a previous discussion it was determined that Domain should be a global runtime variable that can be reused by multiple pallets that require signing within a specific Domain/Chain.

Based on this assumption the `Domain` storage item inside pallet-multibatching was refactores as a Configurable constant in the pallet configuration and all test and benchmarks got fixed accordingly