### PR TITLE
Make item_configs and item_metadata u128

### DIFF
--- a/pallets/nfts/src/features/create_delete_collection.rs
+++ b/pallets/nfts/src/features/create_delete_collection.rs
@@ -150,7 +150,17 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			CollectionAccount::<T, I>::remove(&collection_details.owner, collection);
 			T::Currency::unreserve(&collection_details.owner, collection_details.owner_deposit);
 			CollectionConfigOf::<T, I>::remove(collection);
-			let _ = ItemConfigOf::<T, I>::clear_prefix(collection, witness.item_configs, None);
+			loop {
+				let cursor = ItemConfigOf::<T, I>::clear_prefix(
+					collection,
+					witness.item_configs.try_into().unwrap_or(u32::MAX),
+					None,
+				)
+				.maybe_cursor;
+				if cursor.is_none() {
+					break;
+				}
+			}
 
 			Self::deposit_event(Event::Destroyed { collection });
 

--- a/pallets/nfts/src/lib.rs
+++ b/pallets/nfts/src/lib.rs
@@ -786,7 +786,7 @@ pub mod pallet {
 		/// - `a = witness.attributes`
 		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::destroy(
-			witness.item_metadatas,
+			witness.item_metadatas.try_into().unwrap_or(u32::MAX),
 			witness.attributes,
  		))]
 		pub fn destroy(
@@ -799,7 +799,11 @@ pub mod pallet {
 				.or_else(|origin| ensure_signed(origin).map(Some).map_err(DispatchError::from))?;
 			let details = Self::do_destroy_collection(collection, witness, maybe_check_owner)?;
 
-			Ok(Some(T::WeightInfo::destroy(details.item_metadatas, details.attributes)).into())
+			Ok(Some(T::WeightInfo::destroy(
+				details.item_metadatas.try_into().unwrap_or(u32::MAX),
+				details.attributes,
+			))
+			.into())
 		}
 
 		/// Mint an item of a particular collection.

--- a/pallets/nfts/src/types.rs
+++ b/pallets/nfts/src/types.rs
@@ -102,9 +102,9 @@ pub struct CollectionDetails<AccountId, DepositBalance> {
 	/// The highers Item ID.
 	pub(super) highest_item_id: Option<u128>,
 	/// The total number of outstanding item metadata of this collection.
-	pub(super) item_metadatas: u32,
+	pub(super) item_metadatas: u128,
 	/// The total number of outstanding item configs of this collection.
-	pub(super) item_configs: u32,
+	pub(super) item_configs: u128,
 	/// The total number of attributes for this collection.
 	pub(super) attributes: u32,
 }
@@ -114,10 +114,10 @@ pub struct CollectionDetails<AccountId, DepositBalance> {
 pub struct DestroyWitness {
 	/// The total number of items in this collection that have outstanding item metadata.
 	#[codec(compact)]
-	pub item_metadatas: u32,
+	pub item_metadatas: u128,
 	/// The total number of outstanding item configs of this collection.
 	#[codec(compact)]
-	pub item_configs: u32,
+	pub item_configs: u128,
 	/// The total number of attributes for this collection.
 	#[codec(compact)]
 	pub attributes: u32,


### PR DESCRIPTION
Related: #126

This PR fixes a low severity security issue by which numeric types differ and that might have unintended consequences if the number of items in a collection grows over `u32::MAX`.