### PR TITLE
Migration: allow max_supply to be dropped for serial_mint collections

### DIFF
--- a/pallets/migration/src/benchmarking.rs
+++ b/pallets/migration/src/benchmarking.rs
@@ -138,7 +138,7 @@ pub mod benchmarks {
 		let _ = mint_nft::<T>(1);
 
 		#[extrinsic_call]
-		_(RawOrigin::Signed(migrator), collection.clone());
+		_(RawOrigin::Signed(migrator), collection.clone(), true);
 	}
 
 	impl_benchmark_test_suite!(Migration, crate::mock::new_test_ext(), crate::mock::Test);

--- a/pallets/migration/src/lib.rs
+++ b/pallets/migration/src/lib.rs
@@ -416,6 +416,7 @@ pub mod pallet {
 		pub fn enable_serial_mint(
 			origin: OriginFor<T>,
 			collection: T::CollectionId,
+			drop_max_supply: bool,
 		) -> DispatchResultWithPostInfo {
 			Self::ensure_migrator(origin.clone())?;
 
@@ -424,6 +425,9 @@ pub mod pallet {
 			ensure!(!config.mint_settings.serial_mint, Error::<T>::SerialMintAlreadyEnabled);
 
 			config.mint_settings.serial_mint = true;
+			if drop_max_supply {
+				config.max_supply = None
+			}
 			CollectionConfigOf::<T>::insert(collection, config);
 
 			Self::deposit_event(Event::SerialMintEnabled(collection));


### PR DESCRIPTION
During the migration of collections, max_supply is set on collections to have a better control during the minting process. For collections with serial_mint enabled, specifying max_supply is not required. Therefore, in the final stage of migration, during the collection cleanup where enable_serial_mint() is executed, the max_supply must be removed.