### PR TITLE
Do not use template for generating weights in benchmarks

### DIFF
--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -40,7 +40,6 @@ for PALLET in "${BENCHMARKS[@]}"; do
         --wasm-execution compiled \
         --steps 50 \
         --repeat 20 \
-        --template ./.maintain/template.hbs \
         --output "$OUTPUT"
     echo "Benchmarks for $PALLET successfully generated in $OUTPUT"
 done


### PR DESCRIPTION
The template is not necessary to generate benchmarks, as we are not generating the default ones, but the ones for the actual runtime.