### PR TITLE
Bump authoring duration.

### DIFF
--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -548,7 +548,7 @@ where
 		relay_chain_slot_duration,
 		proposer,
 		collator_service,
-		authoring_duration: Duration::from_millis(1500),
+		authoring_duration: Duration::from_millis(2000),
 		reinitialize: false,
 	};
 


### PR DESCRIPTION
Backing timeout on main net is 2.5s, it should be safe to fully use the promised 2s authoring duration on collators. Paseo is still lacking behind, but in practice I don't even expect problems there.