### PR TITLE
Fix error while running benchmarks

### DIFF
--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -609,10 +609,20 @@ parameter_types! {
 	pub NftsPalletFeatures: PalletFeatures = PalletFeatures::all_enabled();
 	pub const NftsMaxDeadlineDuration: BlockNumber = 12 * 30 * DAYS;
 	pub const NftsCollectionDeposit: Balance = 0;
-	pub const NftsItemDeposit: Balance = 0;
 	pub const NftsMetadataDepositBase: Balance = 0;
 	pub const NftsAttributeDepositBase: Balance = 0;
 	pub const NftsDepositPerByte: Balance = 0;
+
+}
+
+#[cfg(not(feature = "runtime-benchmarks"))]
+parameter_types! {
+	pub const NftsItemDeposit: Balance = 0;
+}
+
+#[cfg(feature = "runtime-benchmarks")]
+parameter_types! {
+	pub const NftsItemDeposit: Balance = EXISTENTIAL_DEPOSIT;
 }
 
 pub type CollectionId = IncrementableU256;

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -591,10 +591,19 @@ parameter_types! {
 	pub NftsPalletFeatures: PalletFeatures = PalletFeatures::all_enabled();
 	pub const NftsMaxDeadlineDuration: BlockNumber = 12 * 30 * DAYS;
 	pub const NftsCollectionDeposit: Balance = 0;
-	pub const NftsItemDeposit: Balance = 0;
 	pub const NftsMetadataDepositBase: Balance = 0;
 	pub const NftsAttributeDepositBase: Balance = 0;
 	pub const NftsDepositPerByte: Balance = 0;
+}
+
+#[cfg(not(feature = "runtime-benchmarks"))]
+parameter_types! {
+	pub const NftsItemDeposit: Balance = 0;
+}
+
+#[cfg(feature = "runtime-benchmarks")]
+parameter_types! {
+	pub const NftsItemDeposit: Balance = EXISTENTIAL_DEPOSIT;
 }
 
 pub type CollectionId = IncrementableU256;


### PR DESCRIPTION
NFT pallet benchmarks require a per-item deposit greater than zero to work. This PR sets it to the existential deposit merely to make benchmarks work.