### PR TITLE
Prepare migration from rococo to paseo

### DIFF
--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -250,7 +250,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("muse"),
 	impl_name: create_runtime_str!("muse"),
 	authoring_version: 1,
-	spec_version: 1016,
+	spec_version: 1017,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This PR prepares the migration from Rococo-Muse to Paseo-Muse. It has been done according to the following guides:

- https://hackmd.io/@bkchr/BkorHJMaA
- https://github.com/paseo-network/support/blob/main/docs/rococo_migration.md#2-migrate-state-and-history

It removes the last relay chain block, which is expected to be rewritten once the chain starts producing blocks on Paseo.