### PR TITLE
revert: Ledger support

### DIFF
--- a/.github/workflows/build-deterministic-runtime.yml
+++ b/.github/workflows/build-deterministic-runtime.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Build ${{ matrix.runtime }} runtime
         id: srtool_build
         uses: chevdor/srtool-actions@v0.9.2
-        env:
-          # Includes metadata hash for production chains.
-          BUILD_OPTS: "--features on-chain-release-build"
         with:
           chain: ${{ matrix.runtime }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6017,7 +6017,6 @@ dependencies = [
  "cumulus-primitives-utility",
  "frame-benchmarking",
  "frame-executive",
- "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -6160,20 +6159,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808b50db46293432a45e63bc15ea51e0ab4c0a1647b8eb114e31a3e698dd6fbe"
 dependencies = [
  "hash-db",
-]
-
-[[package]]
-name = "merkleized-metadata"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c592efaf1b3250df14c8f3c2d952233f0302bb81d3586db2f303666c1cd607"
-dependencies = [
- "array-bytes",
- "blake3",
- "frame-metadata 18.0.0",
- "parity-scale-codec",
- "scale-decode",
- "scale-info",
 ]
 
 [[package]]
@@ -14036,24 +14021,15 @@ name = "substrate-wasm-builder"
 version = "25.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-1#ab5882bbc67bcc48464566a2b48171265147acac"
 dependencies = [
- "array-bytes",
  "build-helper",
  "cargo_metadata",
  "console",
  "filetime",
- "frame-metadata 18.0.0",
  "jobserver",
- "merkleized-metadata",
- "parity-scale-codec",
  "parity-wasm",
  "polkavm-linker",
- "sc-executor",
  "shlex",
- "sp-core",
- "sp-io",
  "sp-maybe-compressed-blob",
- "sp-tracing",
- "sp-version",
  "strum 0.26.3",
  "tempfile",
  "toml 0.8.19",
@@ -14365,7 +14341,6 @@ dependencies = [
  "cumulus-primitives-utility",
  "frame-benchmarking",
  "frame-executive",
- "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,6 @@ pallet-collator-staking = { git = "https://github.com/blockdeep/pallet-collator-
 frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-1", default-features = false }
 frame-benchmarking-cli = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-1" }
 frame-executive = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-1", default-features = false }
-frame-metadata-hash-extension = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-1", default-features = false }
 frame-support = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-1", default-features = false }
 frame-system = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-1", default-features = false }
 frame-system-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-1", default-features = false }

--- a/runtime/mainnet/Cargo.toml
+++ b/runtime/mainnet/Cargo.toml
@@ -37,7 +37,6 @@ account = { workspace = true, default-features = false }
 # Substrate
 frame-benchmarking = { workspace = true, default-features = false, optional = true }
 frame-executive = { workspace = true, default-features = false }
-frame-metadata-hash-extension = { workspace = true, default-features = false }
 frame-support = { workspace = true, default-features = false }
 frame-system = { workspace = true, default-features = false }
 frame-system-benchmarking = { workspace = true, default-features = false, optional = true }
@@ -239,16 +238,3 @@ try-runtime = [
   "parachain-info/try-runtime",
   "pallet-escrow/try-runtime",
 ]
-
-# Enable the metadata hash generation.
-#
-# This is hidden behind a feature because it increases the compile time.
-# The wasm binary needs to be compiled twice, once to fetch the metadata,
-# generate the metadata hash and then a second time with the
-# `RUNTIME_METADATA_HASH` environment variable set for the `CheckMetadataHash`
-# extension.
-metadata-hash = ["substrate-wasm-builder/metadata-hash"]
-
-# A convenience feature for enabling things when doing a build
-# for an on-chain release.
-on-chain-release-build = ["metadata-hash"]

--- a/runtime/mainnet/build.rs
+++ b/runtime/mainnet/build.rs
@@ -1,13 +1,10 @@
-#[cfg(all(feature = "std", feature = "metadata-hash"))]
+#[cfg(feature = "std")]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::init_with_defaults()
-		.enable_metadata_hash("MYTH", 18)
+	substrate_wasm_builder::WasmBuilder::new()
+		.with_current_project()
+		.export_heap_base()
+		.import_memory()
 		.build()
-}
-
-#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
-fn main() {
-	substrate_wasm_builder::WasmBuilder::init_with_defaults().build()
 }
 
 /// The wasm builder is deactivated when compiling

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -112,7 +112,6 @@ pub type SignedExtra = (
 	frame_system::CheckWeight<Runtime>,
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 	cumulus_primitives_storage_weight_reclaim::StorageWeightReclaim<Runtime>,
-	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 
 /// Unchecked extrinsic type as expected by this runtime.

--- a/runtime/testnet/Cargo.toml
+++ b/runtime/testnet/Cargo.toml
@@ -36,7 +36,6 @@ account = { workspace = true, default-features = false }
 # Substrate
 frame-benchmarking = { workspace = true, default-features = false, optional = true }
 frame-executive = { workspace = true, default-features = false }
-frame-metadata-hash-extension = { workspace = true, default-features = false }
 frame-support = { workspace = true, default-features = false }
 frame-system = { workspace = true, default-features = false }
 frame-system-benchmarking = { workspace = true, default-features = false, optional = true }
@@ -235,16 +234,3 @@ try-runtime = [
   "pallet-escrow/try-runtime",
   "pallet-myth-proxy/try-runtime",
 ]
-
-# Enable the metadata hash generation.
-#
-# This is hidden behind a feature because it increases the compile time.
-# The wasm binary needs to be compiled twice, once to fetch the metadata,
-# generate the metadata hash and then a second time with the
-# `RUNTIME_METADATA_HASH` environment variable set for the `CheckMetadataHash`
-# extension.
-metadata-hash = ["substrate-wasm-builder/metadata-hash"]
-
-# A convenience feature for enabling things when doing a build
-# for an on-chain release.
-on-chain-release-build = ["metadata-hash"]

--- a/runtime/testnet/build.rs
+++ b/runtime/testnet/build.rs
@@ -1,13 +1,10 @@
-#[cfg(all(feature = "std", feature = "metadata-hash"))]
+#[cfg(feature = "std")]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::init_with_defaults()
-		.enable_metadata_hash("MUSE", 18)
+	substrate_wasm_builder::WasmBuilder::new()
+		.with_current_project()
+		.export_heap_base()
+		.import_memory()
 		.build()
-}
-
-#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
-fn main() {
-	substrate_wasm_builder::WasmBuilder::init_with_defaults().build()
 }
 
 /// The wasm builder is deactivated when compiling

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -107,7 +107,6 @@ pub type SignedExtra = (
 	frame_system::CheckWeight<Runtime>,
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 	cumulus_primitives_storage_weight_reclaim::StorageWeightReclaim<Runtime>,
-	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 
 /// Unchecked extrinsic type as expected by this runtime.


### PR DESCRIPTION
This PR reverts the changes in #257.

Client-side infrastructure is not ready yet to handle the new metadata hash feature, which is required to enable ledger support. Whenever this issue is addressed the changes will be added again.