### PR TITLE
Increase github action version

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -39,7 +39,7 @@ jobs:
           mkdir -p build
           cp target/production/mythos-node build/mythos-node-${{matrix.cpu}}
       - name: Upload binary
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: binaries
           path: build

--- a/.github/workflows/build-deterministic-runtime.yml
+++ b/.github/workflows/build-deterministic-runtime.yml
@@ -45,7 +45,7 @@ jobs:
         run: cp `dirname ${{ steps.srtool_build.outputs.wasm }}`/*.wasm ./
       - name: Archive Runtime
         if: github.event_name != 'release'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.runtime }}-runtime-${{ github.sha }}
           path: |
@@ -71,7 +71,7 @@ jobs:
 
       - name: Archive Subwasm results
         if: github.event_name != 'release'
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.runtime }}-info
           path: |


### PR DESCRIPTION
This PR fixes a github action deprecation. For more context, see [here](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).

For a CI test, see [here](https://github.com/paritytech/project-mythical/actions/runs/13135717083/job/36650538630).