### PR TITLE
Feat: enable improved_panic_error_reporting in sp-io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ sp-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", tag = 
 sp-core = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-1", default-features = false }
 sp-genesis-builder = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-1", default-features = false }
 sp-inherents = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-1", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-1", default-features = false }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-1", default-features = false, features = ["improved_panic_error_reporting"] }
 sp-keystore = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-1", default-features = false }
 sp-offchain = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-1", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-1", default-features = false }


### PR DESCRIPTION
This is mainly to make the error messages we get when attempting to send invalid transactions to the node to be more helpful.

The feature comes with a warning[[1]](https://github.com/paritytech/polkadot-sdk/blob/master/substrate/primitives/io/Cargo.toml#L99-L101), but it has been there for the latest three years - so I assume we're safe 🙂.