### PR TITLE
Update to polkadot-stable2412-2-with-backport-8040

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7220,7 +7220,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-staking"
 version = "1.2.5"
-source = "git+https://github.com/alexggh/pallet-collator-staking.git?branch=polkadot-stable2412-2-with-backport-8040#8feffafa69d86b46c4ff784f69a02f5ed1730f8e"
+source = "git+https://github.com/blockdeep/pallet-collator-staking.git?branch=polkadot-stable2412-2-with-backport-8040#8feffafa69d86b46c4ff784f69a02f5ed1730f8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "hash-db",
  "log",
@@ -1007,7 +1007,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1766,7 +1766,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.21.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1783,7 +1783,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1806,7 +1806,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -1852,7 +1852,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -1882,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1897,7 +1897,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -1923,7 +1923,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1933,7 +1933,7 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "sp-api",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040)",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
@@ -1945,7 +1945,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1971,7 +1971,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -2008,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -2025,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2061,7 +2061,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -2072,7 +2072,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2085,7 +2085,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2100,7 +2100,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.18.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -2125,7 +2125,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -2134,7 +2134,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2150,7 +2150,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2164,7 +2164,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.11.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2174,7 +2174,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2191,7 +2191,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2208,7 +2208,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2232,7 +2232,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2251,7 +2251,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -2286,7 +2286,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.21.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2327,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3251,7 +3251,7 @@ checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3284,7 +3284,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3308,7 +3308,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "46.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -3346,7 +3346,7 @@ dependencies = [
  "sp-block-builder",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040)",
  "sp-database",
  "sp-externalities",
  "sp-genesis-builder",
@@ -3370,7 +3370,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "14.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -3381,7 +3381,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3397,7 +3397,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -3450,7 +3450,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "array-bytes",
  "const-hex",
@@ -3466,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -3509,7 +3509,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "31.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3522,14 +3522,14 @@ dependencies = [
  "proc-macro-warning 1.84.1",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040)",
  "syn 2.0.99",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.2.0",
@@ -3541,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3551,7 +3551,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "39.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3571,7 +3571,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3585,7 +3585,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -3595,7 +3595,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6279,7 +6279,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "futures",
  "log",
@@ -6298,7 +6298,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "jsonrpsee 0.24.8",
  "parity-scale-codec",
@@ -6936,7 +6936,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-asset-conversion"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6954,7 +6954,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6968,7 +6968,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6985,7 +6985,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7001,7 +7001,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7017,7 +7017,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7032,7 +7032,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7045,7 +7045,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7068,7 +7068,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "aquamarine",
  "docify",
@@ -7089,7 +7089,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "40.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7104,7 +7104,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7123,7 +7123,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -7148,7 +7148,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "38.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7165,7 +7165,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -7183,7 +7183,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7201,7 +7201,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7220,7 +7220,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-staking"
 version = "1.2.5"
-source = "git+https://github.com/blockdeep/pallet-collator-staking.git?tag=v1.2.5#a0514433efb050fce027376fbe55be6c91f6d74e"
+source = "git+https://github.com/alexggh/pallet-collator-staking.git?branch=polkadot-stable2412-2-with-backport-8040#8feffafa69d86b46c4ff784f69a02f5ed1730f8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7240,7 +7240,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7257,7 +7257,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7273,7 +7273,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7288,7 +7288,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7327,7 +7327,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7349,7 +7349,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7362,7 +7362,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7396,7 +7396,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7414,7 +7414,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7436,7 +7436,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -7452,7 +7452,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7471,7 +7471,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7508,7 +7508,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7524,7 +7524,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -7543,7 +7543,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "cfg-if",
  "docify",
@@ -7561,7 +7561,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7596,7 +7596,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7643,7 +7643,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7658,7 +7658,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7676,7 +7676,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7696,7 +7696,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -7706,7 +7706,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7722,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7745,7 +7745,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7762,7 +7762,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7778,7 +7778,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -7788,7 +7788,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7806,7 +7806,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7820,7 +7820,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7838,7 +7838,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7852,7 +7852,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7869,7 +7869,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7890,7 +7890,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7906,7 +7906,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7923,7 +7923,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "39.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7945,7 +7945,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -7954,7 +7954,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7964,7 +7964,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7980,7 +7980,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7995,7 +7995,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8014,7 +8014,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8032,7 +8032,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8048,7 +8048,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "jsonrpsee 0.24.8",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -8064,7 +8064,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -8076,7 +8076,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8095,7 +8095,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8110,7 +8110,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8124,7 +8124,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8138,7 +8138,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -8161,7 +8161,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8179,7 +8179,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -8510,7 +8510,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "bitvec",
  "futures",
@@ -8529,7 +8529,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "always-assert",
  "futures",
@@ -8545,7 +8545,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "derive_more 0.99.19",
  "fatality",
@@ -8569,7 +8569,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "fatality",
@@ -8602,7 +8602,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "22.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "cfg-if",
  "clap",
@@ -8630,7 +8630,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8653,7 +8653,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8664,7 +8664,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "21.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "derive_more 0.99.19",
  "fatality",
@@ -8689,7 +8689,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -8703,7 +8703,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8717,7 +8717,7 @@ dependencies = [
  "sc-network-common",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040)",
  "sp-keystore",
  "tracing-gum",
 ]
@@ -8725,7 +8725,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -8748,7 +8748,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -8767,7 +8767,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -8800,7 +8800,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "futures",
@@ -8830,7 +8830,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "bitvec",
  "futures",
@@ -8851,7 +8851,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8872,7 +8872,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -8887,7 +8887,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "futures",
@@ -8909,7 +8909,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -8923,7 +8923,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8940,7 +8940,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "fatality",
  "futures",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "futures",
@@ -8976,7 +8976,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "fatality",
  "futures",
@@ -8990,7 +8990,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9008,7 +9008,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "always-assert",
  "array-bytes",
@@ -9038,7 +9038,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -9054,7 +9054,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "cpu-time",
  "futures",
@@ -9069,7 +9069,7 @@ dependencies = [
  "sc-executor-wasmtime",
  "seccompiler",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040)",
  "sp-externalities",
  "sp-io",
  "sp-tracing",
@@ -9080,7 +9080,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -9095,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "bs58",
  "futures",
@@ -9114,7 +9114,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -9139,7 +9139,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -9165,7 +9165,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -9174,7 +9174,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -9203,7 +9203,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "derive_more 0.99.19",
@@ -9238,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "futures",
@@ -9260,7 +9260,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.19",
@@ -9276,7 +9276,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "jsonrpsee 0.24.8",
  "mmr-rpc",
@@ -9339,7 +9339,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9390,7 +9390,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -9402,7 +9402,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "18.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -9451,7 +9451,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9485,7 +9485,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "22.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -9593,7 +9593,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "21.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
@@ -9616,7 +9616,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -10544,7 +10544,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -10646,7 +10646,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -11032,7 +11032,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "log",
  "sp-core",
@@ -11043,7 +11043,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "futures",
@@ -11073,7 +11073,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "futures",
  "futures-timer",
@@ -11095,7 +11095,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11110,7 +11110,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "array-bytes",
  "docify",
@@ -11126,7 +11126,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -11137,7 +11137,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -11148,7 +11148,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.50.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -11190,7 +11190,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "fnv",
  "futures",
@@ -11217,7 +11217,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -11243,7 +11243,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "futures",
@@ -11267,7 +11267,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "futures",
@@ -11296,7 +11296,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -11321,7 +11321,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040)",
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
@@ -11332,7 +11332,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "futures",
  "jsonrpsee 0.24.8",
@@ -11354,7 +11354,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11378,7 +11378,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-beefy",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040)",
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -11390,7 +11390,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "futures",
  "jsonrpsee 0.24.8",
@@ -11410,7 +11410,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -11423,7 +11423,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -11457,7 +11457,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040)",
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -11467,7 +11467,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -11487,7 +11487,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "futures",
@@ -11510,7 +11510,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.41.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -11533,7 +11533,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.36.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -11546,7 +11546,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "log",
  "polkavm",
@@ -11557,7 +11557,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.36.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -11575,7 +11575,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "console",
  "futures",
@@ -11592,7 +11592,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -11606,7 +11606,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -11635,7 +11635,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.48.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11686,7 +11686,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -11704,7 +11704,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "ahash",
  "futures",
@@ -11723,7 +11723,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11744,7 +11744,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11780,7 +11780,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "array-bytes",
  "futures",
@@ -11799,7 +11799,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.15.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -11816,7 +11816,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -11853,7 +11853,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -11862,7 +11862,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "futures",
  "jsonrpsee 0.24.8",
@@ -11894,7 +11894,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "jsonrpsee 0.24.8",
  "parity-scale-codec",
@@ -11914,7 +11914,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -11938,7 +11938,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "array-bytes",
  "futures",
@@ -11970,7 +11970,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.49.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "directories",
@@ -12034,7 +12034,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.37.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -12045,7 +12045,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.23.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "clap",
  "fs4",
@@ -12058,7 +12058,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "jsonrpsee 0.24.8",
  "parity-scale-codec",
@@ -12077,7 +12077,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "derive_more 0.99.19",
  "futures",
@@ -12090,7 +12090,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040)",
  "sp-io",
  "sp-std",
 ]
@@ -12098,7 +12098,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "chrono",
  "futures",
@@ -12118,7 +12118,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "chrono",
  "console",
@@ -12146,7 +12146,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -12157,7 +12157,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "38.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "futures",
@@ -12175,7 +12175,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040)",
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
@@ -12188,7 +12188,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "38.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "futures",
@@ -12204,7 +12204,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -12775,7 +12775,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -13090,7 +13090,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "docify",
  "hash-db",
@@ -13112,7 +13112,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -13126,7 +13126,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13138,7 +13138,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -13152,7 +13152,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13164,7 +13164,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -13174,7 +13174,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -13193,7 +13193,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.41.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "futures",
@@ -13208,7 +13208,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.41.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13224,7 +13224,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.41.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13242,7 +13242,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13250,7 +13250,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
@@ -13262,7 +13262,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -13279,7 +13279,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.41.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13290,7 +13290,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -13319,7 +13319,7 @@ dependencies = [
  "secp256k1 0.28.2",
  "secrecy",
  "serde",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -13350,7 +13350,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -13363,17 +13363,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040)",
  "syn 2.0.99",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -13382,7 +13382,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13392,7 +13392,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -13402,7 +13402,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13414,7 +13414,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -13427,7 +13427,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "bytes",
  "docify",
@@ -13439,7 +13439,7 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040)",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -13453,7 +13453,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -13463,7 +13463,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.41.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -13474,7 +13474,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -13483,7 +13483,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-metadata 18.0.0",
  "parity-scale-codec",
@@ -13493,7 +13493,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13504,7 +13504,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -13521,7 +13521,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13534,7 +13534,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -13544,7 +13544,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "backtrace",
  "regex",
@@ -13553,7 +13553,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "33.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -13563,7 +13563,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -13592,7 +13592,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -13611,7 +13611,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "Inflector",
  "expander",
@@ -13624,7 +13624,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13638,7 +13638,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -13651,7 +13651,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "hash-db",
  "log",
@@ -13671,7 +13671,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -13684,7 +13684,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040)",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -13695,12 +13695,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
@@ -13712,7 +13712,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13724,7 +13724,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -13735,7 +13735,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -13744,7 +13744,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13758,7 +13758,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "ahash",
  "hash-db",
@@ -13780,7 +13780,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
@@ -13797,7 +13797,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning 1.84.1",
@@ -13809,7 +13809,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -13821,7 +13821,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -13887,7 +13887,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -13900,7 +13900,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "15.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -13921,7 +13921,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "18.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -13943,7 +13943,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "18.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -14050,7 +14050,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -14062,12 +14062,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -14087,7 +14087,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "http-body-util",
  "hyper 1.6.0",
@@ -14101,7 +14101,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "jsonrpsee 0.24.8",
  "parity-scale-codec",
@@ -14118,7 +14118,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -14918,7 +14918,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -14929,7 +14929,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "expander",
  "proc-macro-crate 3.2.0",
@@ -15803,7 +15803,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -15913,7 +15913,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -16344,7 +16344,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -16355,7 +16355,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.5.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2#863f353d20749caccfd1ccd548cc0cd85291f3a8"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412-2-with-backport-8040#9798a1c987dbb6a70b9a4867ae12a4584f130f4e"
 dependencies = [
  "frame-support",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,104 +54,104 @@ pallet-nfts = { path = "pallets/nfts", default-features = false }
 pallet-myth-proxy = { path = "pallets/myth-proxy", default-features = false }
 
 # External pallets
-pallet-collator-staking = { git = "https://github.com/blockdeep/pallet-collator-staking.git", tag = "v1.2.5", default-features = false }
+pallet-collator-staking = { git = "https://github.com/alexggh/pallet-collator-staking.git", branch = "polkadot-stable2412-2-with-backport-8040", default-features = false }
 
 # Substrate
-frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-frame-benchmarking-cli = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-frame-executive = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-frame-metadata-hash-extension = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-frame-try-runtime = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-pallet-aura = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-pallet-authorship = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-pallet-collective = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-pallet-democracy = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-pallet-message-queue = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }                       #TODO check if was deleted from EPT
-pallet-multisig = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-pallet-preimage = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-pallet-scheduler = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-pallet-session = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-pallet-treasury = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-pallet-utility = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-pallet-proxy = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-pallet-vesting = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-sc-basic-authorship = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-sc-chain-spec = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-sc-cli = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-sc-client-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-sc-consensus = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-sc-executor = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-sc-network = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-sc-service = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-sc-sysinfo = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-sc-telemetry = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-sc-tracing = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-sc-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-sc-transaction-pool-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-sc-offchain = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-sp-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-sp-block-builder = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-sp-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-sp-genesis-builder = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-sp-inherents = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false, features = ["improved_panic_error_reporting"] }
-sp-keystore = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-sp-offchain = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-sp-runtime-interface = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-sp-session = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-sp-std = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-sp-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-sp-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-sp-version = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-substrate-build-script-utils = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-substrate-frame-rpc-system = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-substrate-prometheus-endpoint = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
+frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+frame-benchmarking-cli = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+frame-executive = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+frame-metadata-hash-extension = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+frame-try-runtime = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+pallet-aura = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+pallet-authorship = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+pallet-collective = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+pallet-democracy = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+pallet-message-queue = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }                       #TODO check if was deleted from EPT
+pallet-multisig = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+pallet-preimage = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+pallet-scheduler = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+pallet-session = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+pallet-treasury = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+pallet-utility = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+pallet-proxy = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+pallet-vesting = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+sc-basic-authorship = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+sc-chain-spec = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+sc-cli = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+sc-client-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+sc-consensus = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+sc-executor = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+sc-network = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+sc-service = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+sc-sysinfo = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+sc-telemetry = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+sc-tracing = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+sc-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+sc-transaction-pool-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+sc-offchain = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+sp-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+sp-block-builder = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+sp-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+sp-genesis-builder = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+sp-inherents = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false, features = ["improved_panic_error_reporting"] }
+sp-keystore = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+sp-offchain = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+sp-runtime-interface = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+sp-session = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+sp-std = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+sp-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+sp-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+sp-version = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+substrate-build-script-utils = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+substrate-frame-rpc-system = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+substrate-prometheus-endpoint = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
 
 # Cumulus
-cumulus-primitives-aura = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-cumulus-client-cli = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-cumulus-client-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-cumulus-client-consensus-common = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-cumulus-client-collator = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-cumulus-client-service = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-cumulus-client-consensus-proposer = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-cumulus-pallet-aura-ext = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-cumulus-pallet-session-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-cumulus-pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-cumulus-primitives-core = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-cumulus-primitives-utility = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-cumulus-relay-chain-interface = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-parachain-info = { package = "staging-parachain-info", git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-parachains-common = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
+cumulus-primitives-aura = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+cumulus-client-cli = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+cumulus-client-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+cumulus-client-consensus-common = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+cumulus-client-collator = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+cumulus-client-service = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+cumulus-client-consensus-proposer = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+cumulus-pallet-aura-ext = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+cumulus-pallet-session-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+cumulus-pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+cumulus-primitives-utility = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+cumulus-relay-chain-interface = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+parachain-info = { package = "staging-parachain-info", git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+parachains-common = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
 
 
 # Polkadot
-pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-polkadot-cli = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2" }
-polkadot-parachain-primitives = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-xcm = { package = "staging-xcm", git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
-xcm-runtime-apis = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2", default-features = false }
+pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+polkadot-cli = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040" }
+polkadot-parachain-primitives = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+polkadot-primitives = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+xcm = { package = "staging-xcm", git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+xcm-runtime-apis = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }
 
 # Primitives
 account = { path = "./primitives/account", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ pallet-nfts = { path = "pallets/nfts", default-features = false }
 pallet-myth-proxy = { path = "pallets/myth-proxy", default-features = false }
 
 # External pallets
-pallet-collator-staking = { git = "https://github.com/alexggh/pallet-collator-staking.git", branch = "polkadot-stable2412-2-with-backport-8040", default-features = false }
+pallet-collator-staking = { git = "https://github.com/blockdeep/pallet-collator-staking.git", branch = "polkadot-stable2412-2-with-backport-8040", default-features = false }
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412-2-with-backport-8040", default-features = false }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -328,7 +328,6 @@ pub fn run() -> Result<()> {
 		None => {
 			let runner = cli.create_runner(&cli.run.normalize())?;
 			let collator_options = cli.run.collator_options();
-
 			runner.run_node_until_exit(|config| async move {
 				let hwbench = (!cli.no_hardware_benchmarks)
 					.then_some(config.database.path().map(|database_path| {
@@ -378,7 +377,7 @@ pub fn run() -> Result<()> {
 							testnet_runtime::RuntimeApi,
 							TestnetRuntimeExecutor,
 							sc_network::NetworkWorker<_, _>
-						>(config, polkadot_config, collator_options, id, hwbench)
+						>(config, polkadot_config, collator_options, id, hwbench, cli.run.experimental_max_pov_percentage)
 						.await
 						.map(|r| r.0)
 						.map_err(Into::into)
@@ -391,7 +390,7 @@ pub fn run() -> Result<()> {
 							mainnet_runtime::RuntimeApi,
 							MainnetRuntimeExecutor,
 							sc_network::NetworkWorker<_, _>
-						>(config, polkadot_config, collator_options, id, hwbench)
+						>(config, polkadot_config, collator_options, id, hwbench, cli.run.experimental_max_pov_percentage)
 						.await
 						.map(|r| r.0)
 						.map_err(Into::into)

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -211,6 +211,7 @@ async fn start_node_impl<RuntimeApi, Executor, BIQ, SC, Net>(
 	build_import_queue: BIQ,
 	start_consensus: SC,
 	hwbench: Option<sc_sysinfo::HwBench>,
+	max_pov_percentage: Option<u32>,
 ) -> sc_service::error::Result<(TaskManager, Arc<ParachainClient<RuntimeApi>>)>
 where
 	RuntimeApi: ConstructRuntimeApi<Block, ParachainClient<RuntimeApi>> + Send + Sync + 'static,
@@ -253,6 +254,7 @@ where
 		CollatorPair,
 		OverseerHandle,
 		Arc<dyn Fn(Hash, Option<Vec<u8>>) + Send + Sync>,
+		Option<u32>,
 	) -> Result<(), sc_service::Error>,
 	Net: NetworkBackend<Block, Hash>,
 {
@@ -419,6 +421,7 @@ where
 			collator_key.expect("Command line arguments do not allow this. qed"),
 			overseer_handle,
 			announce_block,
+			max_pov_percentage,
 		)?;
 	}
 
@@ -485,6 +488,7 @@ fn start_consensus<RuntimeApi>(
 	collator_key: CollatorPair,
 	overseer_handle: OverseerHandle,
 	announce_block: Arc<dyn Fn(Hash, Option<Vec<u8>>) + Send + Sync>,
+	max_pov_percentage: Option<u32>,
 ) -> Result<(), sc_service::Error>
 where
 	RuntimeApi: ConstructRuntimeApi<Block, ParachainClient<RuntimeApi>> + Send + Sync + 'static,
@@ -539,6 +543,7 @@ where
 		collator_service,
 		authoring_duration: Duration::from_millis(2000),
 		reinitialize: false,
+		max_pov_percentage,
 	};
 
 	let fut = aura::run::<Block, sp_consensus_aura::sr25519::AuthorityPair, _, _, _, _, _, _, _, _>(
@@ -556,6 +561,7 @@ pub async fn start_parachain_node<RuntimeApi, Executor, Net: NetworkBackend<Bloc
 	collator_options: CollatorOptions,
 	para_id: ParaId,
 	hwbench: Option<sc_sysinfo::HwBench>,
+	max_pov_percentage: Option<u32>,
 ) -> sc_service::error::Result<(TaskManager, Arc<ParachainClient<RuntimeApi>>)>
 where
 	Executor: NativeExecutionDispatch + 'static,
@@ -580,6 +586,7 @@ where
 		build_import_queue::<RuntimeApi>,
 		start_consensus::<RuntimeApi>,
 		hwbench,
+		max_pov_percentage,
 	)
 	.await
 }


### PR DESCRIPTION
To increase throughput mythical-node needs to pick-up the changes from https://github.com/paritytech/polkadot-sdk/pull/8040/files, which increases the default PoV usage from 50% to 85%. Additionally, a CLI flag is also provided `experimental_max_pov_percentage` in case 85% is too optimistic and there is a need to go back to 50% or less.

The PR is not backwards compatible, so it can't be included in `polkadot-stable2412` branch because it would break everyone, but it will be in polkadot-stable2503 and will be picked automatically.

So, we don't have to wait till the repo gets updated `polkadot-stable2503`, which will included other changes as well I created `polkadot-stable2412-2-with-backport-8040` tag in polkadot-sdk that contains `polkadot-stable2412-2` tag + https://github.com/paritytech/polkadot-sdk/pull/8040, nothing else.

Unfortunately, `pallet-collator-staking` needs to be updated, because otherwise compilation fails because of other mismatches, so I created a PR there as well https://github.com/blockdeep/pallet-collator-staking/pull/44, but we need a tag version for it before this PR can be merged.