### PR TITLE
pallet-collator-staking: zero delays

### DIFF
--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -277,7 +277,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: alloc::borrow::Cow::Borrowed("mythos"),
 	impl_name: alloc::borrow::Cow::Borrowed("mythos"),
 	authoring_version: 1,
-	spec_version: 1014,
+	spec_version: 1015,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -621,8 +621,8 @@ parameter_types! {
 	pub const MaxInvulnerables: u32 = 4;
 	pub const MaxStakers: u32 = 200_000;
 	pub const KickThreshold: u32 = 2 * Period::get();
-	pub const BondUnlockDelay: BlockNumber = 3 * DAYS;
-	pub const StakeUnlockDelay: BlockNumber = 3 * DAYS;
+	pub const BondUnlockDelay: BlockNumber = 0;  // previously 3 * DAYS
+	pub const StakeUnlockDelay: BlockNumber = 0; // previously 3 * DAYS
 	pub const AutoCompoundingThreshold: Balance = 2500 * MYTH;
 	/// Rewards are claimable for up to a year.
 	/// Pending to claim rewards past a year will be lost.

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -632,8 +632,8 @@ parameter_types! {
 	pub const MaxInvulnerables: u32 = 4;
 	pub const MaxStakers: u32 = 200_000;
 	pub const KickThreshold: u32 = 2 * Period::get();
-	pub const BondUnlockDelay: BlockNumber = 5 * MINUTES;
-	pub const StakeUnlockDelay: BlockNumber = 2 * MINUTES;
+	pub const BondUnlockDelay: BlockNumber = 0;  // previously 5 * MINUTES
+	pub const StakeUnlockDelay: BlockNumber = 0;  // previously 2 * MINUTES
 	pub const AutoCompoundingThreshold: Balance = 50 * MUSE;
 	/// Rewards are claimable for up to a year.
 	/// Pending to claim rewards past a year will be lost.

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -288,7 +288,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: alloc::borrow::Cow::Borrowed("muse"),
 	impl_name: alloc::borrow::Cow::Borrowed("muse"),
 	authoring_version: 1,
-	spec_version: 1026,
+	spec_version: 1027,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This branch includes the changes pushed to production in [v1,7.2](https://github.com/paritytech/project-mythical/tree/v1.17.2) to remove the unlocking period in the collator-staking pallet.