### PR TITLE
Improve zombienet script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ resources
 .DS_Store
 .idea
 .vscode
+tmp/
 
 # polkadot-launch logs
 *.log

--- a/zombienet-config/mainnet-asset-hub.toml
+++ b/zombienet-config/mainnet-asset-hub.toml
@@ -6,7 +6,7 @@ chain_spec_command = "./bin/chain-spec-generator {% raw %} {{chainName}} {% endr
 
     [[relaychain.nodes]]
     name = "alice"
-    ws_port = 9900
+    rpc_port = 9900
     validator = true
     args = ["--trie-cache-size=0", "--disable-worker-version-check"]
 
@@ -33,7 +33,7 @@ cumulus_based = true
 
     [[parachains.collators]]
     name = "assethub-collator01"
-    ws_port = 9910
+    rpc_port = 9910
     command = "./bin/polkadot-parachain"
     args = ["-lxcm=trace", "--trie-cache-size=0" ]
 
@@ -49,7 +49,7 @@ cumulus_based = true
 
     [[parachains.collators]]
     name = "mythos-collator01"
-    ws_port = 9920
+    rpc_port = 9920
     command = "./target/release/mythos-node"
     args = ["-lxcm=trace", "--trie-cache-size=0"]
 

--- a/zombienet-config/mainnet.toml
+++ b/zombienet-config/mainnet.toml
@@ -6,7 +6,7 @@ chain_spec_command = "./bin/chain-spec-generator {% raw %} {{chainName}} {% endr
 
     [[relaychain.nodes]]
     name = "alice"
-    ws_port = 9900
+    rpc_port = 9900
     validator = true
     args = ["--trie-cache-size=0", "--disable-worker-version-check"]
 
@@ -33,7 +33,7 @@ cumulus_based = true
 
     [[parachains.collators]]
     name = "mythos-collator01"
-    ws_port = 9920
+    rpc_port = 9920
     command = "./target/release/mythos-node"
     args = ["-lxcm=trace", "--trie-cache-size=0"]
 

--- a/zombienet-config/testnet-asset-hub.toml
+++ b/zombienet-config/testnet-asset-hub.toml
@@ -6,7 +6,7 @@ chain_spec_command = "./bin/paseo-chain-spec-generator {% raw %} {{chainName}} {
 
     [[relaychain.nodes]]
     name = "alice"
-    ws_port = 9900
+    rpc_port = 9900
     validator = true
     args = ["--trie-cache-size=0", "--disable-worker-version-check"]
 
@@ -33,7 +33,7 @@ cumulus_based = true
 
     [[parachains.collators]]
     name = "assethub-collator01"
-    ws_port = 9910
+    rpc_port = 9910
     command = "./bin/polkadot-parachain"
     args = ["-lxcm=trace", "--trie-cache-size=0"]
 
@@ -49,7 +49,7 @@ cumulus_based = true
 
     [[parachains.collators]]
     name = "muse-collator01"
-    ws_port = 9920
+    rpc_port = 9920
     command = "./target/release/mythos-node"
     args = ["-lxcm=trace", "--trie-cache-size=0"]
 

--- a/zombienet-config/testnet.toml
+++ b/zombienet-config/testnet.toml
@@ -7,7 +7,7 @@ chain_spec_command = "./bin/paseo-chain-spec-generator {% raw %} {{chainName}} {
 	[[relaychain.nodes]]
 	name = "alice"
 	validator = true
-	ws_port = 9900
+	rpc_port = 9900
 
 	[[relaychain.nodes]]
 	name = "bob"
@@ -22,11 +22,11 @@ chain = "local-v"
 	[[parachains.collators]]
 	name = "muse-collator01"
 	command = "./target/release/mythos-node"
-	ws_port = 9933
+	rpc_port = 9933
 	args = ["--pool-limit 500000 --pool-kbytes 2048000 --rpc-max-connections 10000 -lparachain=debug"]
 
 	[[parachains.collators]]
 	name = "muse-collator02"
-	ws_port = 9922
+	rpc_port = 9922
 	command = "./target/release/mythos-node"
 	args = ["--rpc-max-connections 10000"]

--- a/zombienet.sh
+++ b/zombienet.sh
@@ -32,11 +32,11 @@ build_polkadot() {
   git clone --depth 1 --branch "polkadot-$POLKADOT_V" https://github.com/paritytech/polkadot-sdk.git || echo -n
   pushd polkadot-sdk
   echo "building polkadot executable..."
-  cargo +stable build --release --features fast-runtime
+  cargo build --release --features fast-runtime
   cp target/release/polkadot "$CWD/$BIN_DIR"
   cp target/release/polkadot-execute-worker "$CWD/$BIN_DIR"
   cp target/release/polkadot-prepare-worker "$CWD/$BIN_DIR"
-  cargo +stable build --release -p polkadot-parachain-bin
+  cargo build --release -p polkadot-parachain-bin
   cp target/release/polkadot-parachain "$CWD/$BIN_DIR"
   popd
   popd
@@ -50,7 +50,7 @@ build_chainspec_generators() {
     git clone --depth 1 --branch "$POLKADOT_RUNTIMES_V" https://github.com/polkadot-fellows/runtimes.git polkadot-runtimes || echo -n
     pushd polkadot-runtimes
     echo "building polkadot chain-spec-generator..."
-    cargo +stable build --release --features fast-runtime
+    cargo build --release --features fast-runtime
     cp target/release/chain-spec-generator "$CWD/$BIN_DIR/chain-spec-generator"
     popd
   fi
@@ -58,7 +58,7 @@ build_chainspec_generators() {
     git clone --depth 1 --branch "$PASEO_RUNTIMES_V" https://github.com/paseo-network/runtimes.git paseo-runtimes || echo -n
     pushd paseo-runtimes
     echo "building paseo chain-spec-generator..."
-    cargo +stable build --release --features fast-runtime
+    cargo build --release --features fast-runtime
     cp target/release/chain-spec-generator "$CWD/$BIN_DIR/paseo-chain-spec-generator"
     popd
   fi
@@ -105,28 +105,28 @@ zombienet_build() {
 
 zombienet_testnet() {
   zombienet_init
-  cargo +stable build --release --features testnet-runtime/metadata-hash
+  cargo build --release --features testnet-runtime/metadata-hash
   echo "spawning paseo-local relay chain plus mythos testnet as a parachain..."
   $ZOMBIENET_BIN spawn zombienet-config/testnet.toml -p native
 }
 
 zombienet_testnet_asset_hub() {
   zombienet_init
-  cargo +stable build --release --features testnet-runtime/metadata-hash
+  cargo build --release --features testnet-runtime/metadata-hash
   echo "spawning paseo-local relay chain plus muse testnet as a parachain plus asset-hub..."
   $ZOMBIENET_BIN spawn zombienet-config/testnet-asset-hub.toml -p native
 }
 
 zombienet_mainnet() {
   zombienet_init
-  cargo +stable build --release --features mainnet-runtime/metadata-hash
+  cargo build --release --features mainnet-runtime/metadata-hash
   echo "spawning paseo-local relay chain plus mythos mainnet as a parachain..."
   $ZOMBIENET_BIN spawn zombienet-config/mainnet.toml -p native
 }
 
 zombienet_mainnet_asset_hub() {
   zombienet_init
-  cargo +stable build --release --features mainnet-runtime/metadata-hash
+  cargo build --release --features mainnet-runtime/metadata-hash
   echo "spawning polkadot-local relay chain plus mythos mainnet as a parachain plus asset-hub..."
   $ZOMBIENET_BIN spawn zombienet-config/mainnet-asset-hub.toml -p native
 }

--- a/zombienet.sh
+++ b/zombienet.sh
@@ -3,10 +3,9 @@
 set -e
 
 ZOMBIENET_V=v1.3.128
-POLKADOT_V=stable2412-4
+POLKADOT_V=polkadot-stable2412-4
 POLKADOT_RUNTIMES_V=v1.4.2
 PASEO_RUNTIMES_V=v1.4.1
-BIN_DIR=./bin
 
 case "$(uname -s)" in
 Linux*) MACHINE=Linux ;;
@@ -22,44 +21,45 @@ elif [ $MACHINE = "Mac" ]; then
   IS_LINUX=0
 fi
 
-ZOMBIENET_BIN="${BIN_DIR}/${ZOMBIENET_FILE}"
+SCRIPT_DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+BIN_DIR="$SCRIPT_DIR/bin"
+TEMP_FOLDER="$SCRIPT_DIR/tmp"
+ZOMBIENET_BIN="${BIN_DIR}/zombienet"
 mkdir -p "$BIN_DIR"
 
 build_polkadot() {
   echo "cloning polkadot repository..."
-  CWD=$(pwd)
   pushd /tmp
-  git clone --depth 1 --branch "polkadot-$POLKADOT_V" https://github.com/paritytech/polkadot-sdk.git || echo -n
+  git clone --depth 1 --branch "$POLKADOT_V" https://github.com/paritytech/polkadot-sdk.git || echo -n
   pushd polkadot-sdk
   echo "building polkadot executable..."
   cargo build --release --features fast-runtime
-  cp target/release/polkadot "$CWD/$BIN_DIR"
-  cp target/release/polkadot-execute-worker "$CWD/$BIN_DIR"
-  cp target/release/polkadot-prepare-worker "$CWD/$BIN_DIR"
+  cp target/release/polkadot "$BIN_DIR"
+  cp target/release/polkadot-execute-worker "$BIN_DIR"
+  cp target/release/polkadot-prepare-worker "$BIN_DIR"
   cargo build --release -p polkadot-parachain-bin
-  cp target/release/polkadot-parachain "$CWD/$BIN_DIR"
+  cp target/release/polkadot-parachain "$BIN_DIR"
   popd
   popd
 }
 
 build_chainspec_generators() {
   echo "cloning chain-spec-generators..."
-  CWD=$(pwd)
   pushd /tmp
-  if [ ! -f "$CWD/$BIN_DIR/chain-spec-generator" ]; then
+  if [ ! -f "$BIN_DIR/chain-spec-generator" ]; then
     git clone --depth 1 --branch "$POLKADOT_RUNTIMES_V" https://github.com/polkadot-fellows/runtimes.git polkadot-runtimes || echo -n
     pushd polkadot-runtimes
     echo "building polkadot chain-spec-generator..."
     cargo build --release --features fast-runtime
-    cp target/release/chain-spec-generator "$CWD/$BIN_DIR/chain-spec-generator"
+    cp target/release/chain-spec-generator "$BIN_DIR/chain-spec-generator"
     popd
   fi
-  if [ ! -f "$CWD/$BIN_DIR/paseo-chain-spec-generator" ]; then
+  if [ ! -f "$BIN_DIR/paseo-chain-spec-generator" ]; then
     git clone --depth 1 --branch "$PASEO_RUNTIMES_V" https://github.com/paseo-network/runtimes.git paseo-runtimes || echo -n
     pushd paseo-runtimes
     echo "building paseo chain-spec-generator..."
     cargo build --release --features fast-runtime
-    cp target/release/chain-spec-generator "$CWD/$BIN_DIR/paseo-chain-spec-generator"
+    cp target/release/chain-spec-generator "$BIN_DIR/paseo-chain-spec-generator"
     popd
   fi
   popd
@@ -67,23 +67,23 @@ build_chainspec_generators() {
 
 fetch_polkadot() {
   echo "fetching from polkadot repository..."
-  echo $BIN_DIR
+  echo "$BIN_DIR"
   pushd "$BIN_DIR"
   wget https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-$POLKADOT_V/polkadot
   wget https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-$POLKADOT_V/polkadot-execute-worker
   wget https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-$POLKADOT_V/polkadot-prepare-worker
-  chmod +x *
+  chmod +x ./*
   popd
 }
 
 zombienet_init() {
-  if [ ! -f $ZOMBIENET_BIN ]; then
+  if [ ! -f "$ZOMBIENET_BIN" ]; then
     echo "fetching zombienet executable..."
-    curl -o "$ZOMBIENET_BIN" -LO https://github.com/paritytech/zombienet/releases/download/$ZOMBIENET_V/"$ZOMBIENET_FILE-arm64"
-    chmod +x $ZOMBIENET_BIN
+    curl -o "$ZOMBIENET_BIN" -LO "https://github.com/paritytech/zombienet/releases/download/$ZOMBIENET_V/$ZOMBIENET_FILE-arm64"
+    chmod +x "$ZOMBIENET_BIN"
   fi
   build_chainspec_generators
-  if [ ! -f $BIN_DIR/polkadot ]; then
+  if [ ! -f "$BIN_DIR/polkadot" ]; then
     if [ "$IS_LINUX" -eq 1 ]; then
       fetch_polkadot
     else
@@ -92,43 +92,36 @@ zombienet_init() {
   fi
 }
 
-zombienet_build() {
-  if [ ! -f $ZOMBIENET_BIN ]; then
-    echo "fetching zombienet executable..."
-    curl -LO https://github.com/paritytech/zombienet/releases/download/$ZOMBIENET_V/$ZOMBIENET_BIN
-    chmod +x $ZOMBIENET_BIN
-  fi
-  if [ ! -f $BIN_DIR/polkadot ]; then
-    build_polkadot
-  fi
-}
-
 zombienet_testnet() {
   zombienet_init
   cargo build --release --features testnet-runtime/metadata-hash
   echo "spawning paseo-local relay chain plus mythos testnet as a parachain..."
-  $ZOMBIENET_BIN spawn zombienet-config/testnet.toml -p native
+  rm -rf "$TEMP_FOLDER"
+  $ZOMBIENET_BIN spawn zombienet-config/testnet.toml -p native -d "$TEMP_FOLDER"
 }
 
 zombienet_testnet_asset_hub() {
   zombienet_init
   cargo build --release --features testnet-runtime/metadata-hash
   echo "spawning paseo-local relay chain plus muse testnet as a parachain plus asset-hub..."
-  $ZOMBIENET_BIN spawn zombienet-config/testnet-asset-hub.toml -p native
+  rm -rf "$TEMP_FOLDER"
+  $ZOMBIENET_BIN spawn zombienet-config/testnet-asset-hub.toml -p native -d "$TEMP_FOLDER"
 }
 
 zombienet_mainnet() {
   zombienet_init
   cargo build --release --features mainnet-runtime/metadata-hash
   echo "spawning paseo-local relay chain plus mythos mainnet as a parachain..."
-  $ZOMBIENET_BIN spawn zombienet-config/mainnet.toml -p native
+  rm -rf "$TEMP_FOLDER"
+  $ZOMBIENET_BIN spawn zombienet-config/mainnet.toml -p native -d "$TEMP_FOLDER"
 }
 
 zombienet_mainnet_asset_hub() {
   zombienet_init
   cargo build --release --features mainnet-runtime/metadata-hash
   echo "spawning polkadot-local relay chain plus mythos mainnet as a parachain plus asset-hub..."
-  $ZOMBIENET_BIN spawn zombienet-config/mainnet-asset-hub.toml -p native
+  rm -rf "$TEMP_FOLDER"
+  $ZOMBIENET_BIN spawn zombienet-config/mainnet-asset-hub.toml -p native -d "$TEMP_FOLDER"
 }
 
 print_help() {
@@ -149,7 +142,7 @@ case $SUBCOMMAND in
   ;;
 *)
   shift
-  zombienet_${SUBCOMMAND} $@
+  zombienet_"$SUBCOMMAND" $@
   if [ $? = 127 ]; then
     echo "Error: '$SUBCOMMAND' is not a known SUBCOMMAND." >&2
     echo "Run './zombienet.sh --help' for a list of known subcommands." >&2


### PR DESCRIPTION
Summary of changes:

- After #306 there is no need to maintain the `+stable` wording in zombienet scripts.
- Reverts the changes in the previous PR, as it was actually `rpc_port` the valid keyword in zombienet configuration files for newer versions.
- Improves the zombienet bash script but using double quotes and removing unused functions.
- Creates all zombienet artefacts in a `tmp` local folder to be able to easily spot the generated files deterministically, as it is a recurrent scenario.